### PR TITLE
Allow JAVA_OPTS to be set as a variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,3 +49,6 @@ keycloak_jboss_config_command_timeout: 60
 
 # Configure the firewall to allow access to Keycloak public ports
 keycloak_configure_firewall: true
+
+# Configure the JAVA_OPTS used by the Keycloak service
+keycloak_java_opts: "-Xms1024m -Xmx20480m -XX:MaxPermSize=768m"

--- a/templates/keycloak-sysconfig.j2
+++ b/templates/keycloak-sysconfig.j2
@@ -1,4 +1,4 @@
-JAVA_OPTS="-Xms1024m -Xmx20480m -XX:MaxPermSize=768m"
+JAVA_OPTS={{ keycloak_java_opts }}
 JBOSS_HOME={{ keycloak_jboss_home }}
 KEYCLOAK_BIND_ADDRESS={{ keycloak_bind_address }}
 KEYCLOAK_HTTP_PORT={{ keycloak_http_port }}


### PR DESCRIPTION
This allows the JAVA_OPTS for the keycloak service to be set to a
value specified by an Ansible variable instead of hardcoding it in
the service's sysconfig file.  This can be used to tune things such
as the heap size used by the Java process.