### PR TITLE
add external truststore

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ To configure keycloak to use an external postgresql database, set the following 
 `db_user`: Specify user to use to authenticate to postgresql (optional, default is keycloak).
 `db_password`: Specify user's password to use to authenticate to postgresql (optional, default is password).
 `jdbc_params` : Specific (optional) settings for example `connectTimeout=30` 
+
+To configure keycloak to use an external truststore, set the following variables:
+`keycloak_truststore_location`: Specify the location of the truststore. (Settings for example `/opt/keystore.jks`)
+`keycloak_truststore_password`: Specify truststore's password.
+
 ## Testing
 
 In-tree tests are provided that use molecule to test the role against

--- a/tasks/keycloak_add_truststore.yml
+++ b/tasks/keycloak_add_truststore.yml
@@ -1,0 +1,30 @@
+- name: Ensure Keycloak is started
+  service:
+    name: keycloak
+    state: started
+- name: wait for Keycloak management interface to be available
+  wait_for:
+    port: "{{ keycloak_management_http_port }}"
+    timeout: "{{ keycloak_startup_timeout }}"
+- name: create truststore-config.cli command file
+  template:
+    src: truststore-config.cli.j2
+    dest: "{{ keycloak_config_dir }}/truststore-config.cli"
+    owner: root
+    group: root
+    mode: 0600
+- name: apply keycloak truststore configuration
+  command:
+  args:
+    argv:
+    - "{{ keycloak_jboss_home }}/bin/jboss-cli.sh"
+    - --connect
+    - --timeout={{ keycloak_jboss_config_connect_timeout }}
+    - --command-timeout={{ keycloak_jboss_config_command_timeout }}
+    - --file={{ keycloak_config_dir }}/truststore-config.cli
+  tags:
+  - skip_ansible_lint
+- name: clean up jboss-cli-sh command file
+  file:
+    path: "{{ keycloak_config_dir }}/truststore-config.cli"
+    state: absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -313,6 +313,13 @@
   tags:
   - postgresql
 
+- name: Add truststore for Keycloak
+  become: yes
+  include: keycloak_add_truststore.yml
+  when: keycloak_truststore_password is defined
+  tags:
+  - truststore
+
 - name: create Keycloak admin user
   command:
   args:

--- a/templates/truststore-config.cli.j2
+++ b/templates/truststore-config.cli.j2
@@ -1,0 +1,9 @@
+/subsystem=keycloak-server/spi=truststore:add
+
+/subsystem=keycloak-server/spi=truststore/provider=file:add(enabled=true)
+
+/subsystem=keycloak-server/spi=truststore/provider=file/:map-put(name=properties,key=file, value={{ keycloak_truststore_location }})
+
+/subsystem=keycloak-server/spi=truststore/provider=file/:map-put(name=properties,key=password, value={{ keycloak_truststore_password }})
+
+/subsystem=keycloak-server/spi=truststore/provider=file/:map-put(name=properties,key=hostname-verification-policy, value="WILDCARD")


### PR DESCRIPTION
This allows to add an external keystore as truststore in keycloak.