### PR TITLE
Split the add user parameters

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -318,9 +318,12 @@
   args:
     argv:
     - "{{ keycloak_jboss_home }}/bin/add-user-keycloak.sh"
-    - -r master
-    - -u {{ keycloak_admin_user }}
-    - -p {{ keycloak_admin_password }}
+    - -r
+    - master
+    - -u
+    - {{ keycloak_admin_user }}
+    - -p
+    - {{ keycloak_admin_password }}
     creates: "{{ keycloak_config_dir }}/keycloak-add-user.json"
   become: yes
   notify:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -321,9 +321,9 @@
     - -r
     - master
     - -u
-    - {{ keycloak_admin_user }}
+    - "{{ keycloak_admin_user }}"
     - -p
-    - {{ keycloak_admin_password }}
+    - "{{ keycloak_admin_password }}"
     creates: "{{ keycloak_config_dir }}/keycloak-add-user.json"
   become: yes
   notify:


### PR DESCRIPTION
add-user-keycloak.sh, at least in the latest version of keycloack, generates an invalid user if the flag and value are provided as a single argv. Splitting them fixes the problem and should be still backward compatible.